### PR TITLE
Added type shadowing test

### DIFF
--- a/build-java/test/build/pluto/buildjava/test/BuildJavaTestSuite.java
+++ b/build-java/test/build/pluto/buildjava/test/BuildJavaTestSuite.java
@@ -7,9 +7,10 @@ import org.junit.runners.Suite.SuiteClasses;
 import build.pluto.buildjava.test.simple.CyclicFilesTest;
 import build.pluto.buildjava.test.simple.MultipleFilesTest;
 import build.pluto.buildjava.test.simple.SimpleJavaBuildTest;
+import build.pluto.buildjava.test.simple.TypeShadowingTest;
 
 @RunWith(Suite.class)
-@SuiteClasses({ SimpleJavaBuildTest.class, MultipleFilesTest.class, CyclicFilesTest.class })
+@SuiteClasses({ SimpleJavaBuildTest.class, MultipleFilesTest.class, CyclicFilesTest.class, TypeShadowingTest.class })
 public class BuildJavaTestSuite {
 
 }

--- a/build-java/test/build/pluto/buildjava/test/simple/TypeShadowingTest.java
+++ b/build-java/test/build/pluto/buildjava/test/simple/TypeShadowingTest.java
@@ -1,0 +1,56 @@
+package build.pluto.buildjava.test.simple;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import build.pluto.buildjava.JavaBuilder;
+import build.pluto.buildjava.JavaInput;
+import build.pluto.test.build.ScopedBuildTest;
+import build.pluto.test.build.ScopedPath;
+import build.pluto.test.build.TrackingBuildManager;
+
+
+public class TypeShadowingTest extends ScopedBuildTest {
+
+	@ScopedPath(value = "")
+	private File sourcePath;
+
+	@ScopedPath(value = "Test.java")
+	private File classTestSource;
+
+	@ScopedPath(value = "String.java")
+	private File classStringSource;
+
+	@ScopedPath(value = "bin")
+	private File targetDir;
+
+	private TrackingBuildManager build(File... inputs) throws IOException {
+		TrackingBuildManager manager = new TrackingBuildManager();
+		for (File input : inputs) {
+			manager.require(JavaBuilder.request(new JavaInput(input, targetDir, sourcePath)));
+		}
+		return manager;
+	}
+
+	@Test
+	public void testRebuildAfterAddedSourceFile() throws IOException {
+		// First, build only Test.java.
+		build(classTestSource);
+
+		PrintStream out = new PrintStream(new FileOutputStream(classStringSource));
+		out.println("public class String {}");
+		out.close();
+
+		// The class Test should be rebuilt when String is included in inputs.
+		TrackingBuildManager manager = build(classTestSource, classStringSource);
+		assertEquals(2, manager.getExecutedInputs().size());
+	}
+
+}

--- a/build-java/testdata/TypeShadowingTest/Test.java
+++ b/build-java/testdata/TypeShadowingTest/Test.java
@@ -1,0 +1,4 @@
+public class Test {
+  public void m(String s) {
+  }
+}


### PR DESCRIPTION
This test shows a rebuilding problem in the Java rebuilder. A local class can shadow on-demand and default imports.
